### PR TITLE
Clear transition-duration in end()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 *.sock
+*.swp

--- a/move.js
+++ b/move.js
@@ -153,7 +153,6 @@
     EventEmitter.call(this);
     this.el = el;
     this._props = {};
-    this._clearProps = {};
     this._rotate = 0;
     this._transitionProps = [];
     this._transforms = [];
@@ -399,19 +398,6 @@
   };
 
   /**
-   * Clear `prop`, deferred until `.end()` is invoked.
-   *
-   * @param {String} prop
-   * @return {Move} for chaining
-   * @api public
-   */
-
-  Move.prototype.clearProperty = function(prop){
-    this._clearProps[prop] = true;
-    return this;
-  };
-
-  /**
    * Set a vendor prefixed `prop` with the given `val`.
    *
    * @param {String} prop
@@ -425,23 +411,6 @@
     this.setProperty('-moz-' + prop, val);
     this.setProperty('-ms-' + prop, val);
     this.setProperty('-o-' + prop, val);
-    return this;
-  };
-
-  /**
-   * Clear a vendor prefixed `prop` with the given `val`.
-   *
-   * @param {String} prop
-   * @param {String} val
-   * @return {Move} for chaining
-   * @api public
-   */
-
-  Move.prototype.clearVendorProperty = function(prop, val){
-    this.clearProperty('-webkit-' + prop, val);
-    this.clearProperty('-moz-' + prop, val);
-    this.clearProperty('-ms-' + prop, val);
-    this.clearProperty('-o-' + prop, val);
     return this;
   };
 
@@ -534,18 +503,11 @@
 
   Move.prototype.applyProperties = function(){
     var props = this._props
-      , el = this.el
-	  , clearProps = this._clearProps;
+      , el = this.el;
 
     for (var prop in props) {
       if (props.hasOwnProperty(prop)) {
         el.style.setProperty(prop, props[prop], '');
-      }
-    }
-
-    for (var clearProp in clearProps) {
-      if (clearProps.hasOwnProperty(clearProp)) {
-          el.style.removeProperty(clearProp);
       }
     }
 
@@ -642,6 +604,8 @@
     setTimeout(function(){
       self.setVendorProperty('transform', null);
       self.setVendorProperty('transition-property', null);
+	  self.setVendorProperty('transition-duration', null);
+	  self.applyProperties();
       self.emit('end');
     }, this._duration);
 


### PR DESCRIPTION
This adds the line to also clear the `transition-duration` alongside the `transform` and `transition-property` properties. It also calls `applyProperties()` which means the changes are actually made.
