### PR TITLE
Replace setTimeout for the native transitionend event to emit the 'end' event 

### DIFF
--- a/move.js
+++ b/move.js
@@ -1038,9 +1038,13 @@ Move.prototype.end = function(fn){
   if (fn) this.then(fn);
 
   // emit "end" when complete
-  setTimeout(function(){
+  var end = function() {
     self.emit('end');
-  }, this._duration);
+  };
+
+  this.el.addEventListener('transitionend',       end, false);
+  this.el.addEventListener('webkitTransitionEnd', end, false);
+  this.el.addEventListener('oTransitionEnd',      end, false);
 
   return this;
 };


### PR DESCRIPTION
Using setTimeout can sometime trigger the end event when the transition is still on going (e.g., the browser paused the transition because the window didn't had focus). Using the _transitionend_ event fixes this problem.

[The browser compatibility of _transitionend_ event](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Using_CSS_transitions#Browser_compatibility)
