### PR TITLE
Remove transition duration properties instead of setting them to 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -512,7 +512,7 @@ Move.prototype.reset = function(){
   this.el.style.webkitTransitionDuration =
   this.el.style.mozTransitionDuration =
   this.el.style.msTransitionDuration =
-  this.el.style.oTransitionDuration = 0;
+  this.el.style.oTransitionDuration = '';
   return this;
 };
 


### PR DESCRIPTION
Fixes issue described in https://github.com/visionmedia/move.js/issues/4#issuecomment-44827570

I did not consider **any** other side-effects this change might have. This just fixed the issue for me.
