### PR TITLE
Only pass strings to setProperty as the value argument on IE9 requires DOMString

### DIFF
--- a/move.js
+++ b/move.js
@@ -1201,7 +1201,7 @@ Move.prototype.transition = function(prop){
 
 Move.prototype.applyProperties = function(){
   for (var prop in this._props) {
-    this.el.style.setProperty(prop, this._props[prop], '');
+    this.el.style.setProperty(prop, this._props[prop].toString(), '');
   }
   return this;
 };


### PR DESCRIPTION
An error occured on IE9 when trying to execute:

```
move('.login-container .header')
    .duration(400)
    .ease('in')
    .set('opacity', 0)
    .x(-400)
    .end();
```

So I searched for the problem and found out that IE9 doesn't like it when passing a DOMNumber (opacity 0) into the style.setProperty function.
http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration-setProperty
